### PR TITLE
Correct initialization order for DB reset

### DIFF
--- a/test/TestAutomation.ts
+++ b/test/TestAutomation.ts
@@ -1,11 +1,13 @@
 import { DynamicExecutor, RandomGenerator } from "@nestia/e2e";
-import { IHubChannel } from "@wrtnlabs/os-api/lib/structures/hub/systematic/IHubChannel";
 import chalk from "chalk";
 import { sleep_for } from "tstl";
+
+import { IHubChannel } from "@wrtnlabs/os-api/lib/structures/hub/systematic/IHubChannel";
 
 import { HubChannelProvider } from "../src/providers/hub/systematic/HubChannelProvider";
 
 import { HubConfiguration } from "../src/HubConfiguration";
+import { HubGlobal } from "../src/HubGlobal";
 import HubApi from "../src/api";
 import { HubSetupWizard } from "../src/setup/HubSetupWizard";
 import { PaymentSetupWizard } from "../src/setup/PaymentSetupWizard";
@@ -31,6 +33,10 @@ export namespace TestAutomation {
   export const execute = async <T>(props: IProps<T>): Promise<void> => {
     // CONFIGURE
     const options: IOptions = await getOptions();
+
+    HubGlobal.testing = true;
+    HubGlobal.mock = options.mock;
+
     if (options.reset || !PaymentSetupWizard.prepared())
       await StopWatch.trace("Payment Server")(() => PaymentSetupWizard.setup());
     if (options.reset) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,7 +2,6 @@ import cp from "child_process";
 import { MutexServer } from "mutex-server";
 
 import { HubBackend } from "../src/HubBackend";
-import { HubGlobal } from "../src/HubGlobal";
 import { HubMutex } from "../src/HubMutex";
 import { PaymentSetupWizard } from "../src/setup/PaymentSetupWizard";
 import { TestAutomation } from "./TestAutomation";
@@ -16,10 +15,7 @@ interface IBackend {
 
 const main = async (): Promise<void> => {
   await TestAutomation.execute<IBackend>({
-    open: async (options: TestAutomation.IOptions) => {
-      HubGlobal.testing = true;
-      HubGlobal.mock = options.mock;
-
+    open: async () => {
       const mutex: MutexServer<HubMutex.IHeader> = await HubMutex.master();
       const proxy: cp.ChildProcess = cp.fork(
         `${__dirname}/../src/executable/proxy.js`,


### PR DESCRIPTION
**Problem**
There was a bug where the database reset logic (HubSetupWizard.schema) did not execute correctly when running tests with the pnpm test --reset true command. Instead, only the message "Reset DB: 0 ms" was output.

**Cause**
The HubSetupWizard.schema function includes logic to check if the HubGlobal.testing flag is true before proceeding with the database schema reset.
In the previous code, the point at which TestAutomation.execute checked the options.reset flag and called HubSetupWizard.schema occurred before the props.open function (which sets up the test environment and sets HubGlobal.testing = true).

Consequently, when HubSetupWizard.schema was invoked, HubGlobal.testing was still false (or its default value). This caused the reset logic to be skipped and the function to return immediately. The root cause was an issue with the order of execution, not a failure in passing arguments.


**Solution**
The order of operations within the TestAutomation.execute function has been modified. The setup for HubGlobal.testing = true (and the related HubGlobal.mock = options.mock) is now performed before the options.reset condition is checked and HubSetupWizard.schema is called.

This ensures that the HubGlobal.testing flag is correctly set to true at the time the DB reset is required.

**Result**
As a result, running pnpm test --reset true now correctly resets the database as intended.
